### PR TITLE
Rename `patrol-events` -> `events` in terraform

### DIFF
--- a/terraform/environments/dev/terragrunt.hcl
+++ b/terraform/environments/dev/terragrunt.hcl
@@ -12,5 +12,5 @@ inputs = {
   project_id   = "ecoscope-poc-421907"
   env          = "dev"
   network_name = "ecoscope-dev"
-  service_url  = "patrol-events.dev.ecoscope.io"
+  service_url  = "events.dev.ecoscope.io"
 }

--- a/terraform/environments/terragrunt.hcl
+++ b/terraform/environments/terragrunt.hcl
@@ -2,7 +2,7 @@ remote_state {
   backend = "gcs"
   config = {
     bucket   = "ecoscope-tf-state"
-    prefix   = "workflow-patrol-events/${path_relative_to_include()}/terraform.tfstate"
+    prefix   = "workflow-events/${path_relative_to_include()}/terraform.tfstate"
     project  = "ecoscope-poc-421907"
     location = "us"
   }

--- a/terraform/modules/cloud-run.tf
+++ b/terraform/modules/cloud-run.tf
@@ -1,5 +1,5 @@
 resource "google_cloud_run_v2_service" "default" {
-  name     = "workflow-patrol-events-${var.env}"
+  name     = "workflow-events-${var.env}"
   project  = var.project_id
   location = var.location
   ingress  = var.ingress

--- a/terraform/modules/iam.tf
+++ b/terraform/modules/iam.tf
@@ -1,5 +1,5 @@
 resource "google_service_account" "default" {
-  account_id = "workflow-patrol-events-${var.env}"
+  account_id = "workflow-events-${var.env}"
   project    = var.project_id
 }
 


### PR DESCRIPTION
Following https://github.com/wildlife-dynamics/ecoscope-workflows/pull/330, the workflow formerly known as `patrol-events` is now named just, `events`. I have already renamed this repository. This PR updates the terraform accordingly.