### PR TITLE
add workflow results bucket

### DIFF
--- a/terraform/environments/dev/terragrunt.hcl
+++ b/terraform/environments/dev/terragrunt.hcl
@@ -14,4 +14,5 @@ inputs = {
   network_name                       = "ecoscope-dev"
   service_url                        = "events.dev.ecoscope.io"
   workflows_services_custom_audience = "ecoscope-workflows-services-dev"
+  workflows_results_bucket           = "ecoscope-workflows-results-dev"
 }

--- a/terraform/environments/prod/terragrunt.hcl
+++ b/terraform/environments/prod/terragrunt.hcl
@@ -14,4 +14,5 @@ inputs = {
   network_name                       = "ecoscope-prod"
   service_url                        = "events.ecoscope.io"
   workflows_services_custom_audience = "ecoscope-workflows-services-prod"
+  workflows_results_bucket           = "ecoscope-workflows-results-prod"
 }

--- a/terraform/modules/cloud-run.tf
+++ b/terraform/modules/cloud-run.tf
@@ -32,6 +32,11 @@ resource "google_cloud_run_v2_service" "default" {
         cpu_idle          = true
         startup_cpu_boost = true
       }
+
+      env {
+        name  = "WORKFLOW_RESULTS_ROOT_PATH"
+        value = var.workflows_results_bucket
+      }
     }
   }
   depends_on = [

--- a/terraform/modules/iam.tf
+++ b/terraform/modules/iam.tf
@@ -3,14 +3,22 @@ resource "google_service_account" "default" {
   project    = var.project_id
 }
 
+resource "google_project_iam_member" "serviceAgent" {
+  project = var.project_id
+  role    = "roles/run.serviceAgent"
+  member  = "serviceAccount:${google_service_account.default.email}"
+}
+
+# Github Actions SA is able to use cloud run account
 resource "google_service_account_iam_member" "gha-sa-user" {
   service_account_id = google_service_account.default.id
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:gha-compose@${var.project_id}.iam.gserviceaccount.com"
 }
 
-resource "google_project_iam_member" "serviceAgent" {
-  project = var.project_id
-  role    = "roles/run.serviceAgent"
-  member  = "serviceAccount:${google_service_account.default.email}"
+# Cloud run account can access workflow results bucket
+resource "google_storage_bucket_iam_member" "workflow-results-member" {
+  bucket = var.workflows_results_bucket
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.default.email}"
 }

--- a/terraform/modules/variables.tf
+++ b/terraform/modules/variables.tf
@@ -65,3 +65,7 @@ variable "service_url" {
 variable "workflows_services_custom_audience" {
   type = string
 }
+
+variable "workflows_results_bucket" {
+  type = string
+}


### PR DESCRIPTION
Adds the environment variable WORKFLOW_RESULTS_ROOT_PATH with the bucket to access the workflow results. Also grants permission to the Service Account