### PR TITLE
Remove `linux-aarch64` support for ecoscope-workflows `0.1.0` compat

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -13,7 +13,7 @@
 [project]
   channels = ['https://repo.prefix.dev/ecoscope-workflows/', 'conda-forge']
   name = 'events'
-  platforms = ['linux-64', 'linux-aarch64', 'osx-arm64']
+  platforms = ['linux-64', 'osx-arm64']
 
 [tasks]
   [tasks.compile]


### PR DESCRIPTION
https://github.com/wildlife-dynamics/ecoscope-workflows/pull/834 removed `linux-aarch64` support because:

1. We were not using it; and
2. There is no conda-forge distro of `obstore` for that platform

cc @atmorling @marianobrc for visibility

Once this goes in, I will re-run https://github.com/wildlife-dynamics/ecoscope-workflows/actions/runs/14973300972