### PR TITLE
Fix cut-release trigger in tag.yml

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -63,7 +63,7 @@ jobs:
   cut-release:
     needs: generate-tag
     # only actually cut a tag + release when PRs to main or patch branches are merged
-    if: github.event.action == 'closed' && github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
I noted that https://github.com/ecoscope-platform-workflows-releases/events/actions/runs/16651436915/job/47124990861 did not trigger on merge.

I think this is because the `if:` condition was incorrect, and perhaps does not need the additional condition deleted by this PR.